### PR TITLE
Change neopixels default to on

### DIFF
--- a/src/code.py
+++ b/src/code.py
@@ -42,7 +42,7 @@ GAME_SPEED_START = const(1)
 GAME_SPEED_MOD   = 0.98  # modifies the game speed when line is cleared
 WINDOW_WIDTH     = (SCREEN_WIDTH - GRID_WIDTH - 2) // 2 - WINDOW_GAP * 2
 FONT_HEIGHT      = terminalio.FONT.get_bounding_box()[1]
-NEOPIXELS        = False
+NEOPIXELS        = True
 
 TETROMINOS = [
     {


### PR DESCRIPTION
As of CircuitPython 10.0.0-beta.3, the display glitches which occurs during NeoPixel writes are no longer present. The NeoPixel feature is now enabled by default, but the option is still available to disable this feature.