### PR TITLE
Fix quit action logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Tetris, _**Fruit Jamified!**_
 | Drop: Hard       | Z             | B       | Button #1 & #3      |
 | Pause            | Enter         | Start   | Button #1 & #2      |
 | Quit (reload)    | Escape        | Select  | Button #1 & #2 & #3 |
-* Quit only works when paused
 
 ## Credits
 

--- a/code.py
+++ b/code.py
@@ -1294,7 +1294,7 @@ def do_action(action:int) -> None:
             play_song(False)
         elif game_state == STATE_WAITING and action != ACTION_QUIT:
             reset_game()
-        elif action == ACTION_QUIT:
+        if action == ACTION_QUIT:
             gamepad.disconnect()
             peripherals.deinit()
             supervisor.reload()


### PR DESCRIPTION
Previously, a logic error prevented the "Quit" action from working unless within the "Pause" state. This update fixes this logic error to allow the "Quit" action to occur at any point within the game.